### PR TITLE
add openai version processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ curl $ENDPOINT_URL/chat/completions \
 python examples/inference/api_server_openai/query_http_requests.py
 
 # using OpenAI SDK
+# please install openai in current env by running: pip install openai>=1.0
 export OPENAI_API_BASE=http://localhost:8000/v1
 export OPENAI_API_KEY="not_a_real_key"
 python examples/inference/api_server_openai/query_openai_sdk.py

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ python examples/inference/api_server_openai/query_http_requests.py
 
 # using OpenAI SDK
 export OPENAI_API_BASE=http://localhost:8000/v1
-export OPENAI_API_KEY=$your_openai_api_key
+export OPENAI_API_KEY="not_a_real_key"
 python examples/inference/api_server_openai/query_openai_sdk.py
 ```
 Or you can serve specific model to a simple endpoint according to the `port` and `route_prefix` parameters in configuration file,

--- a/docs/serve.md
+++ b/docs/serve.md
@@ -64,7 +64,7 @@ python examples/inference/api_server_openai/query_http_requests.py
 
 # using OpenAI SDK
 export OPENAI_API_BASE=http://localhost:8000/v1
-export OPENAI_API_KEY=$your_openai_api_key
+export OPENAI_API_KEY="not_a_real_key"
 python examples/inference/api_server_openai/query_openai_sdk.py
 ```
 ### Serving Model to a Simple Endpoint

--- a/docs/serve.md
+++ b/docs/serve.md
@@ -63,6 +63,7 @@ curl $ENDPOINT_URL/chat/completions \
 python examples/inference/api_server_openai/query_http_requests.py
 
 # using OpenAI SDK
+# please install openai in current env by running: pip install openai>=1.0
 export OPENAI_API_BASE=http://localhost:8000/v1
 export OPENAI_API_KEY="not_a_real_key"
 python examples/inference/api_server_openai/query_openai_sdk.py

--- a/examples/inference/api_server_openai/query_openai_sdk.py
+++ b/examples/inference/api_server_openai/query_openai_sdk.py
@@ -15,7 +15,7 @@
 #
 
 import argparse
-import openai
+from openai import OpenAI
 
 parser = argparse.ArgumentParser(
     description="Example script to query with openai sdk", add_help=True
@@ -41,49 +41,21 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-version = openai.__version__
-version_content = version.split(".")
+client = OpenAI()
+# # List all models.
+models = client.models.list()
+print(models.data, "\n")
 
-if version_content[0] == "0":
-    # List all models.
-    models = openai.Model.list()
-    print(models)
-
-    # Note: not all arguments are currently supported and will be ignored by the backend.
-    chat_completion = openai.ChatCompletion.create(
-        model=args.model_name,
-        messages=[
-            {"role": "assistant", "content": "You are a helpful assistant."},
-            {"role": "user", "content": "Tell me a long story with many words."},
-        ],
-        stream=args.streaming_response,
-        max_tokens=args.max_new_tokens,
-        temperature=args.temperature,
-        top_p=args.top_p,
-    )
-    print(chat_completion)
-elif version_content[0] == "1" and version_content[1] <= "9":
-    from openai import OpenAI
-
-    client = OpenAI()
-    # # List all models.
-    models = client.models.list()
-    print(models.data, "\n")
-
-    # Note: not all arguments are currently supported and will be ignored by the backend.
-    chat_completion = client.chat.completions.create(
-        model=args.model_name,
-        messages=[
-            {"role": "assistant", "content": "You are a helpful assistant."},
-            {"role": "user", "content": "Tell me a long story with many words."},
-        ],
-        stream=args.streaming_response,
-        max_tokens=args.max_new_tokens,
-        temperature=args.temperature,
-        top_p=args.top_p,
-    )
-    print(chat_completion)
-else:
-    raise ImportError(
-        f"please check openai version, needs to be lower than 1.9.0, but found {version}"
-    )
+# Note: not all arguments are currently supported and will be ignored by the backend.
+chat_completion = client.chat.completions.create(
+    model=args.model_name,
+    messages=[
+        {"role": "assistant", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Tell me a long story with many words."},
+    ],
+    stream=args.streaming_response,
+    max_tokens=args.max_new_tokens,
+    temperature=args.temperature,
+    top_p=args.top_p,
+)
+print(chat_completion)

--- a/examples/inference/api_server_openai/query_openai_sdk.py
+++ b/examples/inference/api_server_openai/query_openai_sdk.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-import openai
 import argparse
+import openai
 
 parser = argparse.ArgumentParser(
     description="Example script to query with openai sdk", add_help=True
@@ -41,20 +41,49 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-# List all models.
-models = openai.Model.list()
-print(models)
+version = openai.__version__
+version_content = version.split(".")
 
-# Note: not all arguments are currently supported and will be ignored by the backend.
-chat_completion = openai.ChatCompletion.create(
-    model=args.model_name,
-    messages=[
-        {"role": "assistant", "content": "You are a helpful assistant."},
-        {"role": "user", "content": "Tell me a long story with many words."},
-    ],
-    stream=args.streaming_response,
-    max_tokens=args.max_new_tokens,
-    temperature=args.temperature,
-    top_p=args.top_p,
-)
-print(chat_completion)
+if version_content[0] == "0":
+    # List all models.
+    models = openai.Model.list()
+    print(models)
+
+    # Note: not all arguments are currently supported and will be ignored by the backend.
+    chat_completion = openai.ChatCompletion.create(
+        model=args.model_name,
+        messages=[
+            {"role": "assistant", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Tell me a long story with many words."},
+        ],
+        stream=args.streaming_response,
+        max_tokens=args.max_new_tokens,
+        temperature=args.temperature,
+        top_p=args.top_p,
+    )
+    print(chat_completion)
+elif version_content[0] == "1" and version_content[1] <= "9":
+    from openai import OpenAI
+
+    client = OpenAI()
+    # # List all models.
+    models = client.models.list()
+    print(models.data, "\n")
+
+    # Note: not all arguments are currently supported and will be ignored by the backend.
+    chat_completion = client.chat.completions.create(
+        model=args.model_name,
+        messages=[
+            {"role": "assistant", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Tell me a long story with many words."},
+        ],
+        stream=args.streaming_response,
+        max_tokens=args.max_new_tokens,
+        temperature=args.temperature,
+        top_p=args.top_p,
+    )
+    print(chat_completion)
+else:
+    raise ImportError(
+        f"please check openai version, needs to be lower than 1.9.0, but found {version}"
+    )


### PR DESCRIPTION
Related to https://github.com/intel/llm-on-ray/issues/66. APIs has changed when openai version is 1.x. Now, it'll call corresponding APIs according to current env's openai version.