### PR TITLE
[inference][issue-67] support pip install in docker container

### DIFF
--- a/.github/workflows/workflow_inference.yml
+++ b/.github/workflows/workflow_inference.yml
@@ -84,7 +84,7 @@ jobs:
             DF_SUFFIX=".bigdl-cpu"
           elif [[ ${{ matrix.model }} == "llama-2-7b-chat-hf-vllm" ]]; then
             DF_SUFFIX=".vllm"
-          elif [[ ${{ matrix.model }} == "gpt2" ]]; then
+          elif [[ ${{ matrix.model }} == "gpt-j-6b" ]]; then
             DF_SUFFIX=".cpu_and_deepspeed.pip_non_editable"
           else
             DF_SUFFIX=".cpu_and_deepspeed"

--- a/.github/workflows/workflow_inference.yml
+++ b/.github/workflows/workflow_inference.yml
@@ -84,6 +84,8 @@ jobs:
             DF_SUFFIX=".bigdl-cpu"
           elif [[ ${{ matrix.model }} == "llama-2-7b-chat-hf-vllm" ]]; then
             DF_SUFFIX=".vllm"
+          elif [[ ${{ matrix.model }} == "gpt2" ]]; then
+            DF_SUFFIX=".cpu_and_deepspeed.pip_non_editable"
           else
             DF_SUFFIX=".cpu_and_deepspeed"
           fi

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+# with [tools.setuptools] in pyproject.toml, the configs below work in both baremetal and container
+include inference/**/*.yaml

--- a/dev/docker/Dockerfile.bigdl-cpu
+++ b/dev/docker/Dockerfile.bigdl-cpu
@@ -28,7 +28,7 @@ COPY ./pyproject.toml .
 
 RUN mkdir ./finetune && mkdir ./inference
 
-RUN --mount=type=cache,target=/root/.cache/pip pip install -e .[bigdl-cpu] -f https://developer.intel.com/ipex-whl-stable-cpu \
+RUN --mount=type=cache,target=/root/.cache/pip pip install .[bigdl-cpu] -f https://developer.intel.com/ipex-whl-stable-cpu \
     -f https://download.pytorch.org/whl/torch_stable.html
 
 # Used to invalidate docker build cache with --build-arg CACHEBUST=$(date +%s)

--- a/dev/docker/Dockerfile.bigdl-cpu
+++ b/dev/docker/Dockerfile.bigdl-cpu
@@ -25,10 +25,11 @@ RUN --mount=type=cache,target=/opt/conda/pkgs conda init bash && \
     conda install python==3.9
 
 COPY ./pyproject.toml .
+COPY ./MANIFEST.in .
 
 RUN mkdir ./finetune && mkdir ./inference
 
-RUN --mount=type=cache,target=/root/.cache/pip pip install .[bigdl-cpu] -f https://developer.intel.com/ipex-whl-stable-cpu \
+RUN --mount=type=cache,target=/root/.cache/pip pip install -e .[bigdl-cpu] -f https://developer.intel.com/ipex-whl-stable-cpu \
     -f https://download.pytorch.org/whl/torch_stable.html
 
 # Used to invalidate docker build cache with --build-arg CACHEBUST=$(date +%s)

--- a/dev/docker/Dockerfile.cpu_and_deepspeed
+++ b/dev/docker/Dockerfile.cpu_and_deepspeed
@@ -25,10 +25,11 @@ RUN --mount=type=cache,target=/opt/conda/pkgs conda init bash && \
     conda install python==3.9
 
 COPY ./pyproject.toml .
+COPY ./MANIFEST.in .
 
 RUN mkdir ./finetune && mkdir ./inference
 
-RUN --mount=type=cache,target=/root/.cache/pip pip install .[cpu,deepspeed] -f https://developer.intel.com/ipex-whl-stable-cpu \
+RUN --mount=type=cache,target=/root/.cache/pip pip install -e .[cpu,deepspeed] -f https://developer.intel.com/ipex-whl-stable-cpu \
     -f https://download.pytorch.org/whl/torch_stable.html
 
 RUN ds_report

--- a/dev/docker/Dockerfile.cpu_and_deepspeed
+++ b/dev/docker/Dockerfile.cpu_and_deepspeed
@@ -28,7 +28,7 @@ COPY ./pyproject.toml .
 
 RUN mkdir ./finetune && mkdir ./inference
 
-RUN --mount=type=cache,target=/root/.cache/pip pip install -e .[cpu,deepspeed] -f https://developer.intel.com/ipex-whl-stable-cpu \
+RUN --mount=type=cache,target=/root/.cache/pip pip install .[cpu,deepspeed] -f https://developer.intel.com/ipex-whl-stable-cpu \
     -f https://download.pytorch.org/whl/torch_stable.html
 
 RUN ds_report

--- a/dev/docker/Dockerfile.cpu_and_deepspeed.pip_non_editable
+++ b/dev/docker/Dockerfile.cpu_and_deepspeed.pip_non_editable
@@ -22,22 +22,17 @@ RUN --mount=type=cache,target=/opt/conda/pkgs conda init bash && \
     unset -f conda && \
     export PATH=$CONDA_DIR/bin/:${PATH} && \
     conda config --add channels intel && \
-    conda install -y -c conda-forge python==3.9 gxx=12.3 gxx_linux-64=12.3
+    conda install python==3.9
 
-COPY ./pyproject.toml .
-COPY ./MANIFEST.in .
-COPY ./dev/scripts/install-vllm-cpu.sh .
+# copy all checkedout file for later non-editable pip
+COPY . .
 
-RUN mkdir ./finetune && mkdir ./inference
-
-RUN --mount=type=cache,target=/root/.cache/pip pip install -e .[cpu] -f https://developer.intel.com/ipex-whl-stable-cpu \
+RUN --mount=type=cache,target=/root/.cache/pip pip install .[cpu,deepspeed] -f https://developer.intel.com/ipex-whl-stable-cpu \
     -f https://download.pytorch.org/whl/torch_stable.html
 
-# Install vllm-cpu
-# Activate base first for loading g++ envs ($CONDA_PREFIX/etc/conda/activate.d/*)
-RUN --mount=type=cache,target=/root/.cache/pip \
-    source /opt/conda/bin/activate base && ./install-vllm-cpu.sh
+RUN ds_report
 
-# TODO: workaround, remove this when fixed in vllm-cpu upstream
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install xformers
+# Used to invalidate docker build cache with --build-arg CACHEBUST=$(date +%s)
+ARG CACHEBUST=1
+COPY ./dev/scripts/install-oneapi.sh /tmp
+RUN /tmp/install-oneapi.sh

--- a/dev/docker/Dockerfile.vllm
+++ b/dev/docker/Dockerfile.vllm
@@ -29,7 +29,7 @@ COPY ./dev/scripts/install-vllm-cpu.sh .
 
 RUN mkdir ./finetune && mkdir ./inference
 
-RUN --mount=type=cache,target=/root/.cache/pip pip install -e .[cpu] -f https://developer.intel.com/ipex-whl-stable-cpu \
+RUN --mount=type=cache,target=/root/.cache/pip pip install .[cpu] -f https://developer.intel.com/ipex-whl-stable-cpu \
     -f https://download.pytorch.org/whl/torch_stable.html
 
 # Install vllm-cpu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "fastapi<=0.108.0",
     "ray[tune]",
     "ray[serve]",
+    "gradio==4.11.0",
     "gymnasium",
     "dm-tree",
     "tensorboard",
@@ -36,6 +37,7 @@ dependencies = [
     "deltatuner==1.1.9",
     "py-cpuinfo",
     "pydantic-yaml",
+    "paramiko==3.4.0",
 ]
 
 [project.optional-dependencies]
@@ -65,11 +67,6 @@ deepspeed = [
 
 bigdl-cpu = [
     "bigdl-llm[all]"
-]
-
-ui = [
-    "gradio==4.11.0",
-    "paramiko==3.4.0",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "fastapi<=0.108.0",
     "ray[tune]",
     "ray[serve]",
-    "gradio==4.11.0",
     "gymnasium",
     "dm-tree",
     "tensorboard",
@@ -37,7 +36,6 @@ dependencies = [
     "deltatuner==1.1.9",
     "py-cpuinfo",
     "pydantic-yaml",
-    "paramiko==3.4.0",
 ]
 
 [project.optional-dependencies]
@@ -69,8 +67,15 @@ bigdl-cpu = [
     "bigdl-llm[all]"
 ]
 
+ui = [
+    "gradio==4.11.0",
+    "paramiko==3.4.0",
+]
+
 [tool.setuptools]
-packages = ["finetune", "inference"]
+# with MANIFEST.in, the configs below work in both baremetal and container
+package-dir = {"inference" = "inference", "finetune" = "finetune"}
+include-package-data = true
 
 [project.urls]
 Repository = "https://github.com/intel/llm-on-ray.git"


### PR DESCRIPTION
1. changed how setuptools find packages in pyproject.toml. Added manifest.in to include yaml files under models.  After this two modifications, pip can install llm-on-ray correctly in both baremetal and container.
2. to verify container pip installation, added an non-editable pip installation for one of model (gpt-j-6b for now, will switch to 'gpt2' for nightly since it's slower. All project files copied to image.)