### PR TITLE
change mpt-7b to mpt-7b-chat for bigdl

### DIFF
--- a/inference/models/bigdl/mpt-7b-bigdl.yaml
+++ b/inference/models/bigdl/mpt-7b-bigdl.yaml
@@ -10,7 +10,7 @@ ipex:
   enabled: false
   precision: bf16
 model_description:
-  model_id_or_path: mosaicml/mpt-7b
+  model_id_or_path: mosaicml/mpt-7b-chat
   bigdl: true
   tokenizer_name_or_path: EleutherAI/gpt-neox-20b
   chat_processor: ChatModelGptJ


### PR DESCRIPTION
According to https://github.com/intel-analytics/BigDL/issues/10177, we need to change mpt-7b to mpt-7b-chat for bigdl for now.