### PR TITLE
[pretrain]  Fix missing module imports 

### DIFF
--- a/common/__init__.py
+++ b/common/__init__.py
@@ -4,8 +4,8 @@ from . import agentenv
 from .torch_config import TorchConfig  # noqa: F401
 from typing import Dict, Any
 import sys
-from .config import Config
-from .init import init
+from .config import Config  # noqa: F401
+from .init import init  # noqa: F401
 
 
 @load_check_decorator  # noqa: F405 # may be undefined, or defined from star imports

--- a/common/__init__.py
+++ b/common/__init__.py
@@ -4,6 +4,8 @@ from . import agentenv
 from .torch_config import TorchConfig  # noqa: F401
 from typing import Dict, Any
 import sys
+from .config import Config
+from .init import init
 
 
 @load_check_decorator  # noqa: F405 # may be undefined, or defined from star imports


### PR DESCRIPTION
This PR addresses an issue where necessary module imports for the pretraining process were inadvertently removed during a recent code standardization effort. The missing imports have been identified and restored to ensure the pretraining functionality operates correctly.