### PR TITLE
Fix vllm CI for crypt.h missing

### DIFF
--- a/dev/docker/Dockerfile.vllm
+++ b/dev/docker/Dockerfile.vllm
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/opt/conda/pkgs conda init bash && \
     unset -f conda && \
     export PATH=$CONDA_DIR/bin/:${PATH} && \
     conda config --add channels intel && \
-    conda install -y -c conda-forge python==3.9 gxx=12.3 gxx_linux-64=12.3
+    conda install -y -c conda-forge python==3.9 gxx=12.3 gxx_linux-64=12.3 libxcrypt
 
 COPY ./pyproject.toml .
 COPY ./MANIFEST.in .


### PR DESCRIPTION
The issue is caused by upstream changes.

https://github.com/stanford-futuredata/ColBERT/issues/309

Signed-off-by: Wu, Xiaochang <xiaochang.wu@intel.com>