### PR TITLE
Remove fastapi from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "ray>=2.9",
     "typing>=3.7.4.3",
     "tabulate",
-    "fastapi<=0.108.0",
     "ray[tune]",
     "ray[serve]",
     "gymnasium",


### PR DESCRIPTION
Dependabot reported issue for fastapi and required version >= 0.109.1.
As ray[serve] will install fastapi, remove it from pyproject.toml