### PR TITLE
Bug fixing when running on Gaudi node using openai compatible API

### DIFF
--- a/dev/scripts/install-ui.sh
+++ b/dev/scripts/install-ui.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # install dependency
-pip install "gradio<=3.36.1" "langchain<=0.0.329" "langchain_community<=0.0.13" "paramiko<=3.4.0" "sentence-transformers" "faiss-cpu"
+pip install "gradio<=3.36.1" "gradio_client==0.7.3" "langchain<=0.0.329" "langchain_community<=0.0.13" "paramiko<=3.4.0" "sentence-transformers" "faiss-cpu" "lz4"
 
 # install pyrecdp from source
 pip install 'git+https://github.com/intel/e2eAIOK.git#egg=pyrecdp&subdirectory=RecDP'


### PR DESCRIPTION
Some small fixings when running Demo on SDP gaudi node

1. SSH system info fetching fix
When do system info query from habana docker, this is system msg I got
```
root@visiondemo:~/llm-ray# ssh localhost -p 3022 'export TERM=xterm; echo $(top -n 1 -b | head -n 4 | tail -n 2)'
Warning: Permanently added '[localhost]:3022' (ED25519) to the list of known hosts.
 * Starting OpenBSD Secure Shell server sshd
   ...done.
%Cpu(s): 2.9 us, 0.9 sy, 0.7 ni, 95.6 id, 0.0 wa, 0.0 hi, 0.0 si, 0.0 st MiB Mem : 1031616.+total, 632128.9 free, 191866.5 used, 207621.1 buff/cache
```
Problem:
More than 1 line received, current parsing reports error

Solution:
Add a fix to only using last line for parsing

2. Empty stream output using openai compatible API
Solution:
Fix by checking 'choices' key word

3. Support openAI compatible API in multi Session demo
 