### PR TITLE
Fix bug: deal with string in config file

### DIFF
--- a/llm_on_ray/inference/utils.py
+++ b/llm_on_ray/inference/utils.py
@@ -19,7 +19,13 @@ from ray.util.queue import Queue
 import torch
 from typing import Dict, Any, List, Optional, Union
 from enum import Enum
-from llm_on_ray.inference.inference_config import InferenceConfig, DEVICE_CPU, DEVICE_HPU
+from llm_on_ray.inference.inference_config import (
+    InferenceConfig,
+    DEVICE_CPU,
+    DEVICE_HPU,
+    PRECISION_BF16,
+    PRECISION_FP32,
+)
 from llm_on_ray.inference.api_openai_backend.openai_protocol import ChatMessage
 
 
@@ -127,6 +133,10 @@ def decide_torch_dtype(infer_conf: InferenceConfig, hf_config=None):
 
     if infer_conf.model_description.config.torch_dtype:
         # respect user config
+        if infer_conf.model_description.config.torch_dtype == PRECISION_BF16:
+            infer_conf.model_description.config.torch_dtype = torch.bfloat16
+        elif infer_conf.model_description.config.torch_dtype == PRECISION_FP32:
+            infer_conf.model_description.config.torch_dtype = torch.float32
         return
     elif hf_config is None:
         # default to float32 if hf_config is not supplied

--- a/tests/inference/test_utils.py
+++ b/tests/inference/test_utils.py
@@ -87,12 +87,12 @@ def test_decide_torch_dtype_cpu_without_ipex(mock_infer_conf):
 
 
 def test_decide_torch_dtype_respect_user_config(mock_infer_conf):
-    mock_infer_conf.model_description.config.torch_dtype = torch.float16
+    mock_infer_conf.model_description.config.torch_dtype = "bf16"
     mock_infer_conf.device = DEVICE_CPU
 
     decide_torch_dtype(mock_infer_conf)
 
-    assert mock_infer_conf.model_description.config.torch_dtype == torch.float16
+    assert mock_infer_conf.model_description.config.torch_dtype == torch.bfloat16
 
 
 def test_decide_torch_dtype_hpu_with_deepspeed(mock_infer_conf):
@@ -107,17 +107,17 @@ def test_decide_torch_dtype_hpu_with_deepspeed(mock_infer_conf):
 def test_decide_torch_dtype_with_hf_config_torch_dtype(mock_infer_conf):
     mock_infer_conf.device = DEVICE_CPU
     mock_infer_conf.ipex.enabled = True
-    hf_config = {"torch_dtype": torch.float16}
+    hf_config = {"torch_dtype": torch.bfloat16}
 
     decide_torch_dtype(mock_infer_conf, hf_config)
 
-    assert mock_infer_conf.model_description.config.torch_dtype == torch.float16
+    assert mock_infer_conf.model_description.config.torch_dtype == torch.bfloat16
 
 
 def test_decide_torch_dtype_with_hf_config_torch_dtype_as_attribute(mock_infer_conf):
     class HFConfig:
         def __init__(self):
-            self.torch_dtype = torch.float16
+            self.torch_dtype = torch.bfloat16
 
     mock_infer_conf.device = DEVICE_CPU
     mock_infer_conf.ipex.enabled = True
@@ -125,7 +125,7 @@ def test_decide_torch_dtype_with_hf_config_torch_dtype_as_attribute(mock_infer_c
 
     decide_torch_dtype(mock_infer_conf, hf_config)
 
-    assert mock_infer_conf.model_description.config.torch_dtype == torch.float16
+    assert mock_infer_conf.model_description.config.torch_dtype == torch.bfloat16
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
follow up of #166 
As @KepingYan found, decide_torch_dtype doesn't consider string type, this is a bug.