### PR TITLE
Fix StoppingCriteriaSub parameters to be compatible with latest Transformers

### DIFF
--- a/llm_on_ray/inference/utils.py
+++ b/llm_on_ray/inference/utils.py
@@ -95,7 +95,7 @@ class StoppingCriteriaSub(StoppingCriteria):
         super().__init__()
         self.stops = stops
 
-    def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor):
+    def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs):
         for stop in self.stops:
             length = 1 if len(stop.size()) == 0 else stop.size()[0]
             if torch.all((stop == input_ids[0][-length:])).item():


### PR DESCRIPTION
This PR is a very simple fix. The latest Transformers defines `StoppingCriteria.__call__()` to accept `**kwargs`, while our `StoppingCriteriaSub` does not. Therefore, when optimum_habana calls it with `token_idx`, it errors.

With this fix, llama2-7b and llama3-8b will work with latest optimum-habana. In fact, the reason 70b models was not affected is that I forgot to pass stopping criteria there.

But actually we don't need to define `StoppingCriteriaSub` at all. Transformers have a few pre-defined StoppingCriteria, such as `MaxLengthCriteria` and `StopStringCriteria`. We can just use `StopStringCriteria` to replace it. 

Also it's not needed in most cases. But we should support specifying stopping criteria, such as max length, eos_tokens, etc. This is left to refactor in the future.


