### PR TITLE
Fix max_new_tokens for HPU predictcor

### DIFF
--- a/llm_on_ray/inference/predictors/hpu_predictor.py
+++ b/llm_on_ray/inference/predictors/hpu_predictor.py
@@ -176,7 +176,7 @@ class HPUPredictor(Predictor):
         config["lazy_mode"] = self.use_lazy_mode
         config["hpu_graphs"] = self.use_hpu_graphs
         # max_new_tokens is required for hpu
-        if "max_new_tokens" not in config:
+        if config.get("max_new_tokens") is None:
             config["max_new_tokens"] = 128
 
     def get_streamer(self):


### PR DESCRIPTION

Fix a server error when sending http request without max_tokens config. 

max_new_tokens is set in config but its value is None.
