### PR TITLE
[Finetune] Resolve the exception caused by missing validation data and the missing gaudi_config parameter in GaudiTrainer.

### DIFF
--- a/examples/finetune/gpt_j_6b/finetune_hpu.yaml
+++ b/examples/finetune/gpt_j_6b/finetune_hpu.yaml
@@ -1,5 +1,6 @@
 General:
   base_model: EleutherAI/gpt-j-6b
+  gaudi_config_name: Habana/gpt2
   gpt_base_model: true
   output_dir: /tmp/llm-ray/output
   save_strategy: no

--- a/llm_on_ray/finetune/finetune.py
+++ b/llm_on_ray/finetune/finetune.py
@@ -274,6 +274,7 @@ def train_func(config: Dict[str, Any]):
         from optimum.habana.transformers import GaudiTrainer
         from optimum.habana.transformers import GaudiTrainingArguments
         from optimum.habana import GaudiConfig
+
         # If gaudi_config_name is provided, load gaudi_config from huggingface model hub(https://huggingface.co/Habana), otherwise use default gaudi_config
         if config["general"].get("gaudi_config_name") is not None:
             gaudi_config = GaudiConfig.from_pretrained(

--- a/llm_on_ray/finetune/finetune.py
+++ b/llm_on_ray/finetune/finetune.py
@@ -274,10 +274,15 @@ def train_func(config: Dict[str, Any]):
         from optimum.habana.transformers import GaudiTrainer
         from optimum.habana.transformers import GaudiTrainingArguments
         from optimum.habana import GaudiConfig
-
-        gaudi_config = GaudiConfig()
-        gaudi_config.use_fused_adam = True
-        gaudi_config.use_fused_clip_norm = True
+        # If gaudi_config_name is provided, load gaudi_config from huggingface model hub(https://huggingface.co/Habana), otherwise use default gaudi_config
+        if config["general"].get("gaudi_config_name") is not None:
+            gaudi_config = GaudiConfig.from_pretrained(
+                config["general"].get("gaudi_config_name"),
+            )
+        else:
+            gaudi_config = GaudiConfig()
+            gaudi_config.use_fused_adam = True
+            gaudi_config.use_fused_clip_norm = True
         training_args = convert_to_training_args(GaudiTrainingArguments, config)
         trainer = GaudiTrainer(
             model=model,

--- a/llm_on_ray/finetune/finetune.py
+++ b/llm_on_ray/finetune/finetune.py
@@ -259,7 +259,9 @@ def train_func(config: Dict[str, Any]):
             model=model,
             args=training_args,
             train_dataset=tokenized_datasets["train"],
-            eval_dataset=tokenized_datasets["validation"],
+            eval_dataset=tokenized_datasets["validation"]
+            if tokenized_datasets.get("validation") is not None
+            else None,
             tokenizer=tokenizer,
             data_collator=data_collator,
         )
@@ -271,13 +273,20 @@ def train_func(config: Dict[str, Any]):
     elif device in ["hpu"]:
         from optimum.habana.transformers import GaudiTrainer
         from optimum.habana.transformers import GaudiTrainingArguments
+        from optimum.habana import GaudiConfig
 
+        gaudi_config = GaudiConfig()
+        gaudi_config.use_fused_adam = True
+        gaudi_config.use_fused_clip_norm = True
         training_args = convert_to_training_args(GaudiTrainingArguments, config)
         trainer = GaudiTrainer(
             model=model,
             args=training_args,
+            gaudi_config=gaudi_config,
             train_dataset=tokenized_datasets["train"],
-            eval_dataset=tokenized_datasets["validation"],
+            eval_dataset=tokenized_datasets["validation"]
+            if tokenized_datasets.get("validation") is not None
+            else None,
             tokenizer=tokenizer,
             data_collator=data_collator,
         )

--- a/llm_on_ray/finetune/finetune_config.py
+++ b/llm_on_ray/finetune/finetune_config.py
@@ -53,6 +53,7 @@ class DeltatunerConfig(BaseModel):
 class General(BaseModel):
     base_model: str
     tokenizer_name: Optional[str] = None
+    gaudi_config_name: Optional[str] = None
     gpt_base_model: bool
     output_dir: str
     resume_from_checkpoint: Optional[str] = None


### PR DESCRIPTION
1. add gaudi_config. When using Gaudi, it will be load gaudi_config.json. One is to download from huggingface with gaudi_config_name and the other is to create new.

![image](https://github.com/intel/llm-on-ray/assets/45281494/71f48d11-47d3-4ea8-8a81-7fc3581a14db)

2. fix validation dataset to be None