### PR TITLE
Add new_deployment option for serve

### DIFF
--- a/llm_on_ray/inference/serve.py
+++ b/llm_on_ray/inference/serve.py
@@ -133,7 +133,8 @@ def main(argv=None):
     )
     parser.add_argument(
         "--openai_route_prefix",
-        action="store_true",
+        default=None,
+        type=str,
         help="Whether to use default '/' route prefix or deploy at new route prefix.",
     )
 

--- a/llm_on_ray/inference/serve.py
+++ b/llm_on_ray/inference/serve.py
@@ -131,6 +131,11 @@ def main(argv=None):
     parser.add_argument(
         "--max_batch_size", default=None, type=int, help="The max batch size for dynamic batching."
     )
+    parser.add_argument(
+        "--openai_route_prefix",
+        action="store_true",
+        help="Whether to use default '/' route prefix or deploy at new route prefix.",
+    )
 
     # Print help if no arguments were provided
     if len(sys.argv) == 1:
@@ -158,7 +163,10 @@ def main(argv=None):
         host = "127.0.0.1" if args.serve_local_only else "0.0.0.0"
         print("Service is running with deployments:" + str(deployments))
         print("Service is running models:" + str(model_list))
-        openai_serve_run(deployments, model_list, host, "/", args.port, args.max_ongoing_requests)
+        if args.openai_route_prefix:
+            openai_serve_run(deployments, model_list, host, "/" + args.openai_route_prefix, args.port, args.max_ongoing_requests)
+        else:    
+            openai_serve_run(deployments, model_list, host, "/", args.port, args.max_ongoing_requests)
 
     msg = "Service is deployed successfully."
     if args.keep_serve_terminal:

--- a/llm_on_ray/inference/serve.py
+++ b/llm_on_ray/inference/serve.py
@@ -154,9 +154,9 @@ def main(argv=None):
     )
     parser.add_argument(
         "--openai_route_prefix",
-        default=None,
+        default="/",
         type=str,
-        help="Whether to use default '/' route prefix or deploy at new route prefix.",
+        help="The openai_route_prefix must start with a forward slash ('/')",
     )
 
     # Print help if no arguments were provided
@@ -186,24 +186,15 @@ def main(argv=None):
         print("Service is running with deployments:" + str(deployments))
         print("Service is running models:" + str(model_list))
 
-        if args.openai_route_prefix:
-            openai_serve_run(
-              deployments, 
-              model_list, 
-              host, 
-              "/" + args.openai_route_prefix, 
-              args.port, 
-              args.max_ongoing_requests, 
-              args.max_num_seqs,)
-        else:    
-            openai_serve_run(
-              deployments, 
-              model_list, 
-              host, 
-              "/", 
-              args.port, 
-              args.max_ongoing_requests, 
-              args.max_num_seqs,
+        openai_serve_run(
+            deployments,
+            model_list,
+            host,
+            args.openai_route_prefix,
+            args.port,
+            args.max_ongoing_requests,
+            args.max_num_seqs,
+        )
 
     msg = "Service is deployed successfully."
     if args.keep_serve_terminal:


### PR DESCRIPTION
* Objective: allow user to deploy and keep multiple model endpoints alive so that they can easily test and benchmark different models. (as current OpenAI compatible API server deployment will kill the previous deployment)
* **
Changes: 
-  add `--new_deployment` option to `serve.py`
- if this option is enabled, the application name and route prefix will be using `name` as defined in the deployment config instead of `router` and `/`
- for OpenAI compatible API deployment, the endpoint URL will become `http://localhost:8000/{name}/v1` instead of `http://localhost:8000/v1`


enable option for deploying without overriding previous deployment