### PR TITLE
Add application name option for openai serve

### DIFF
--- a/llm_on_ray/inference/api_server_openai.py
+++ b/llm_on_ray/inference/api_server_openai.py
@@ -72,14 +72,14 @@ def router_application(deployments, model_list, max_ongoing_requests, max_num_se
 
 
 def openai_serve_run(
-    deployments, model_list, host, route_prefix, port, max_ongoing_requests, max_num_seqs
+    deployments, model_list, host, route_prefix, application_name, port, max_ongoing_requests, max_num_seqs
 ):
     router_app = router_application(deployments, model_list, max_ongoing_requests, max_num_seqs)
 
     serve.start(http_options={"host": host, "port": port})
     serve.run(
         router_app,
-        name="router",
+        name=application_name,
         route_prefix=route_prefix,
     ).options(
         stream=True,

--- a/llm_on_ray/inference/api_server_openai.py
+++ b/llm_on_ray/inference/api_server_openai.py
@@ -72,7 +72,14 @@ def router_application(deployments, model_list, max_ongoing_requests, max_num_se
 
 
 def openai_serve_run(
-    deployments, model_list, host, route_prefix, application_name, port, max_ongoing_requests, max_num_seqs
+    deployments,
+    model_list,
+    host,
+    route_prefix,
+    application_name,
+    port,
+    max_ongoing_requests,
+    max_num_seqs,
 ):
     router_app = router_application(deployments, model_list, max_ongoing_requests, max_num_seqs)
 

--- a/llm_on_ray/inference/serve.py
+++ b/llm_on_ray/inference/serve.py
@@ -133,7 +133,8 @@ def main(argv=None):
     )
     parser.add_argument(
         "--openai_route_prefix",
-        action="store_true",
+        default=None,
+        type=str,
         help="Whether to use default '/' route prefix or deploy at new route prefix.",
     )
 

--- a/llm_on_ray/inference/serve.py
+++ b/llm_on_ray/inference/serve.py
@@ -131,6 +131,11 @@ def main(argv=None):
     parser.add_argument(
         "--max_batch_size", default=None, type=int, help="The max batch size for dynamic batching."
     )
+    parser.add_argument(
+        "--openai_route_prefix",
+        action="store_true",
+        help="Whether to use default '/' route prefix or deploy at new route prefix.",
+    )
 
     # Print help if no arguments were provided
     if len(sys.argv) == 1:
@@ -158,7 +163,10 @@ def main(argv=None):
         host = "127.0.0.1" if args.serve_local_only else "0.0.0.0"
         print("Service is running with deployments:" + str(deployments))
         print("Service is running models:" + str(model_list))
-        openai_serve_run(deployments, model_list, host, "/", args.port, args.max_ongoing_requests)
+        if args.openai_route_prefix:
+            openai_serve_run(deployments, model_list, host, "/" + args.openai_route_prefix, args.port, args.max_ongoing_requests)
+        else:    
+            openai_serve_run(deployments, model_list, host, "/", args.port, args.max_ongoing_requests)
 
     msg = "Service is deployed successfully."
     if args.keep_serve_terminal:

--- a/llm_on_ray/inference/serve.py
+++ b/llm_on_ray/inference/serve.py
@@ -158,6 +158,12 @@ def main(argv=None):
         type=str,
         help="The openai_route_prefix must start with a forward slash ('/')",
     )
+    parser.add_argument(
+        "--openai_application_name",
+        default="router",
+        type=str,
+        help="If not specified, the application name will be 'router'.",
+    )
 
     # Print help if no arguments were provided
     if len(sys.argv) == 1:
@@ -191,6 +197,7 @@ def main(argv=None):
             model_list,
             host,
             args.openai_route_prefix,
+            args.openai_application_name,
             args.port,
             args.max_ongoing_requests,
             args.max_num_seqs,

--- a/llm_on_ray/inference/serve.py
+++ b/llm_on_ray/inference/serve.py
@@ -154,9 +154,9 @@ def main(argv=None):
     )
     parser.add_argument(
         "--openai_route_prefix",
-        default=None,
+        default="/",
         type=str,
-        help="Whether to use default '/' route prefix or deploy at new route prefix.",
+        help="The openai_route_prefix must start with a forward slash ('/')",
     )
 
     # Print help if no arguments were provided
@@ -186,24 +186,15 @@ def main(argv=None):
         print("Service is running with deployments:" + str(deployments))
         print("Service is running models:" + str(model_list))
 
-        if args.openai_route_prefix:
-            openai_serve_run(
-              deployments, 
-              model_list, 
-              host, 
-              "/" + args.openai_route_prefix, 
-              args.port, 
-              args.max_ongoing_requests, 
-              args.max_num_seqs,)
-        else:    
-            openai_serve_run(
-              deployments, 
-              model_list, 
-              host, 
-              "/", 
-              args.port, 
-              args.max_ongoing_requests, 
-              args.max_num_seqs,
+        openai_serve_run(
+            deployments,
+            model_list,
+            host,
+            args.openai_route_prefix,
+            args.port,
+            args.max_ongoing_requests,
+            args.max_num_seqs,
+        )
 
     msg = "Service is deployed successfully."
     if args.keep_serve_terminal:


### PR DESCRIPTION
added `--openai_application_name` option to allow user to set different application name in ray serve.
Default application name is `router` if not specified.